### PR TITLE
fix(@aws-amplify/storage): Add acl as an option param for put file

### DIFF
--- a/packages/storage/__tests__/Storage-unit-test.ts
+++ b/packages/storage/__tests__/Storage-unit-test.ts
@@ -414,6 +414,30 @@ describe('Storage', () => {
             curCredSpyOn.mockClear();
         });
 
+        test('put object with acl specified', async () => {
+            const curCredSpyOn = jest.spyOn(Credentials, 'get')
+                .mockImplementationOnce(() => {
+                    return new Promise((res, rej) => {
+                        res({});
+                    });
+                });
+
+            const storage = new Storage(options);
+            const spyon = jest.spyOn(S3.prototype, 'upload');
+
+            expect.assertions(2);
+            expect(await storage.put('key', 'obejct', { acl: 'public-read' })).toEqual({ "key": "path/itemsKey" });
+            expect(spyon.mock.calls[0][0]).toEqual({
+                "Body": "obejct",
+                "Bucket": "bucket",
+                "ContentType": "binary/octet-stream",
+                "Key": "public/key",
+                "ACL": "public-read"
+            });
+            spyon.mockClear();
+            curCredSpyOn.mockClear();
+        });
+
         test('credentials not ok', async () => {
             const curCredSpyOn = jest.spyOn(Credentials, 'get')
                 .mockImplementationOnce(() => {

--- a/packages/storage/src/Storage.ts
+++ b/packages/storage/src/Storage.ts
@@ -152,7 +152,7 @@ export default class StorageClass {
         if (!credentialsOK) { return Promise.reject('No credentials'); }
 
         const opt = Object.assign({}, this._options, options);
-        const { bucket, region, credentials, level, track } = opt;
+        const { bucket, region, credentials, level, track, acl } = opt;
         const { contentType, contentDisposition, cacheControl, expires, metadata } = opt;
         const type = contentType ? contentType : 'binary/octet-stream';
 
@@ -165,8 +165,9 @@ export default class StorageClass {
             Bucket: bucket,
             Key: final_key,
             Body: object,
-            ContentType: type
+            ContentType: type,
         };
+        if (acl) { params.ACL = acl; }
         if (cacheControl) { params.CacheControl = cacheControl; }
         if (contentDisposition) { params.ContentDisposition = contentDisposition; }
         if (expires) { params.Expires = expires; }


### PR DESCRIPTION
*Issue #, if available:*
fix: #960 

*Description of changes:*
Add `acl` as an available parameter to do put request for S3 Storage

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
